### PR TITLE
MCC-207101 - remove the header field from display

### DIFF
--- a/AppConnectSwift/FieldViewController.swift
+++ b/AppConnectSwift/FieldViewController.swift
@@ -103,7 +103,6 @@ class FieldViewController: UIViewController, UIPickerViewDelegate, UIPickerViewD
         let fieldInfo = [
             "FieldOID: \(field.fieldOID)",
             "Type: \(field.fieldType)",
-            "Header: \(field.header)",
             "Number: \(field.fieldNumber)",
             "Label: \(field.label)",
             "Format: \(fieldFormat)",


### PR DESCRIPTION
This PR removes the header field to match the Android version. We're just using the label field in the sample apps.
