### PR TITLE
[MCC-169447] Updated appconnect-ios example to changes in babbage API.

### DIFF
--- a/AppConnectSwift/FormListViewController.swift
+++ b/AppConnectSwift/FormListViewController.swift
@@ -52,7 +52,7 @@ class FormListViewController: UITableViewController {
             // Keep track of loaded subjects so that we know when all have been loaded
             var loadedSubjectsAndErrors : [AnyObject] = []
             
-            client.loadSubjectsForUser(user, inDatastore: datastore) { (subjects: [AnyObject]!, error: NSError!) -> Void in
+            client.loadSubjectsForUser(user) { (subjects: [AnyObject]!, error: NSError!) -> Void in
                 if error != nil {
                     loadedSubjectsAndErrors.append(error)
                     if loadedSubjectsAndErrors.count == subjects.count {
@@ -71,7 +71,7 @@ class FormListViewController: UITableViewController {
                 // these methods are only usable during the lifetime of this
                 // temporary datastore.
                 for subject in subjects as! [MDSubject]! {
-                    client.loadFormsForSubject(subject, inDatastore: datastore) { (forms: [AnyObject]!, error: NSError!) -> Void in
+                    client.loadFormsForSubject(subject) { (forms: [AnyObject]!, error: NSError!) -> Void in
                         loadedSubjectsAndErrors.append(subject)
                         
                         // When all subjects have been loaded, populate the UI and stop the spinner

--- a/AppConnectSwift/MultiPageFormViewController.swift
+++ b/AppConnectSwift/MultiPageFormViewController.swift
@@ -73,7 +73,7 @@ class MultiPageFormViewController: UIViewController, UIPageViewControllerDelegat
         let f = datastore.formWithID(self.formID)
         
         // The form provided to the client method must have been loaded from the datastore provided
-        client.sendResponsesForForm(f, inDatastore: datastore, deviceID: "fake-device-id", completion: { (error: NSError!) -> Void in
+        client.sendResponsesForForm(f, deviceID: "fake-device-id", completion: { (error: NSError!) -> Void in
             if error != nil {
                 self.showDialog("Error", message: "There was an error submitting the form", completion: nil)
             } else {

--- a/AppConnectSwift/OnePageFormViewController.swift
+++ b/AppConnectSwift/OnePageFormViewController.swift
@@ -91,7 +91,7 @@ class OnePageFormViewController: UIViewController {
         let f = datastore.formWithID(self.formID)
         
         // The form provided to the client method must have been loaded from the datastore provided
-        client.sendResponsesForForm(f, inDatastore: datastore, deviceID: "fake-device-id", completion: { (error: NSError!) -> Void in
+        client.sendResponsesForForm(f, deviceID: "fake-device-id", completion: { (error: NSError!) -> Void in
             if error != nil {
                 self.showDialog("Error", message: "There was an error submitting the form", completion: nil)
             } else {


### PR DESCRIPTION
Babbage API calls that previously took a StoredObject and a Datastore object, now only take that StoredObject, and Babbage handles the rest. 
These changes to the app connect example update the relevant API calls to remove the Datastore parameter. 

do not merge until 307 (https://github.com/mdsol/babbage/pull/307) is merged. 
