### PR TITLE
MCC-188780 - disable bitcode, update Babbage Pod

### DIFF
--- a/AppConnectSwift.xcodeproj/project.pbxproj
+++ b/AppConnectSwift.xcodeproj/project.pbxproj
@@ -8,15 +8,15 @@
 
 /* Begin PBXBuildFile section */
 		33DF3A5D20D7C27322C5EBC2 /* libPods-AppConnectSwift.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 68B4DBFBB3AADD545AED0B96 /* libPods-AppConnectSwift.a */; };
-		520806B91C29FB640070BA54 /* FieldViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520806B81C29FB640070BA54 /* FieldViewController.swift */; settings = {ASSET_TAGS = (); }; };
-		523069721C319AEA0012A478 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523069711C319AEA0012A478 /* UIViewController+Extensions.swift */; settings = {ASSET_TAGS = (); }; };
-		523069741C31C04D0012A478 /* README.md in Sources */ = {isa = PBXBuildFile; fileRef = 523069731C31C04D0012A478 /* README.md */; settings = {ASSET_TAGS = (); }; };
-		5232B6DE1C29B4BA006D10EC /* demo_accounts.json in Resources */ = {isa = PBXBuildFile; fileRef = 5232B6DD1C29B4BA006D10EC /* demo_accounts.json */; settings = {ASSET_TAGS = (); }; };
-		5232B6E01C29B5B5006D10EC /* sample.json in Resources */ = {isa = PBXBuildFile; fileRef = 5232B6DF1C29B5B5006D10EC /* sample.json */; settings = {ASSET_TAGS = (); }; };
-		5268D2A31C2497FC00C75096 /* FormListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5268D2A21C2497FC00C75096 /* FormListViewController.swift */; settings = {ASSET_TAGS = (); }; };
-		526B32951C249BD400C4DBB8 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526B32941C249BD400C4DBB8 /* LoginViewController.swift */; settings = {ASSET_TAGS = (); }; };
-		52C702521C3332A200FC00CF /* ReviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C702511C3332A200FC00CF /* ReviewViewController.swift */; settings = {ASSET_TAGS = (); }; };
-		52EC841B1C31863900683D5B /* Babbage.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 52EC841A1C31863900683D5B /* Babbage.podspec */; settings = {ASSET_TAGS = (); }; };
+		520806B91C29FB640070BA54 /* FieldViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 520806B81C29FB640070BA54 /* FieldViewController.swift */; };
+		523069721C319AEA0012A478 /* UIViewController+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 523069711C319AEA0012A478 /* UIViewController+Extensions.swift */; };
+		523069741C31C04D0012A478 /* README.md in Sources */ = {isa = PBXBuildFile; fileRef = 523069731C31C04D0012A478 /* README.md */; };
+		5232B6DE1C29B4BA006D10EC /* demo_accounts.json in Resources */ = {isa = PBXBuildFile; fileRef = 5232B6DD1C29B4BA006D10EC /* demo_accounts.json */; };
+		5232B6E01C29B5B5006D10EC /* sample.json in Resources */ = {isa = PBXBuildFile; fileRef = 5232B6DF1C29B5B5006D10EC /* sample.json */; };
+		5268D2A31C2497FC00C75096 /* FormListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5268D2A21C2497FC00C75096 /* FormListViewController.swift */; };
+		526B32951C249BD400C4DBB8 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 526B32941C249BD400C4DBB8 /* LoginViewController.swift */; };
+		52C702521C3332A200FC00CF /* ReviewViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52C702511C3332A200FC00CF /* ReviewViewController.swift */; };
+		52EC841B1C31863900683D5B /* Babbage.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 52EC841A1C31863900683D5B /* Babbage.podspec */; };
 		AAE6D3411C21C355009B0C6B /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE6D3401C21C355009B0C6B /* AppDelegate.swift */; };
 		AAE6D3431C21C355009B0C6B /* MultiPageFormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE6D3421C21C355009B0C6B /* MultiPageFormViewController.swift */; };
 		AAE6D3451C21C355009B0C6B /* OnePageFormViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAE6D3441C21C355009B0C6B /* OnePageFormViewController.swift */; };
@@ -318,6 +318,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
@@ -362,6 +363,7 @@
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_BITCODE = NO;
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;

--- a/AppConnectSwift/Babbage.podspec
+++ b/AppConnectSwift/Babbage.podspec
@@ -3,7 +3,7 @@ password = ENV['ARTIFACTORY_PASSWORD'] || raise("You must set an artifactory pas
 
 Pod::Spec.new do |s|
     s.name               = "Babbage"
-    s.version            = "1.1-pre.129"
+    s.version            = "1.1-pre.136"
     s.summary            = "The Medidata Patient Cloud SDK"
     s.homepage           = "https://github.com/mdsol/babbage"
     s.license            = { type: "Proprietary", text: "TBD" }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -20,7 +20,7 @@ PODS:
   - AFNetworking/UIKit (2.5.3):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
-  - Babbage (1.1-pre.129):
+  - Babbage (1.1-pre.136):
     - AFNetworking (= 2.5.3)
     - HTMLReader (~> 0.7.1)
     - OpenSSL-Universal (~> 1.0.1j)
@@ -38,7 +38,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AFNetworking: e1d86c2a96bb5d2e7408da36149806706ee122fe
-  Babbage: ba588afb5f4a5cec3b1303fa5647834bf936e6e2
+  Babbage: f7ce3e9f9f58ca48d3e43098f9eb35c098689ddb
   HTMLReader: e6ba09514d125f45e810b6c6c1cebf3542f04d89
   OpenSSL-Universal: 85ef63bf81d0741b03c8719cd29685c37c59518d
   UICKeyChainStore: c5719c814e8bd69e74e4a0fc09daf8f4d6257a59


### PR DESCRIPTION
This PR updates the Babbage Pod to the latest version. It also disables bitcode so that the app can run on the device (see: http://stackoverflow.com/a/32692501/141615). The `pbxproj` file was also updated, as a result of using Xcode 7.2.
