### PR TITLE
MCC-208121 - remove credentials, center spinner

### DIFF
--- a/AppConnectSwift/FormListViewController.swift
+++ b/AppConnectSwift/FormListViewController.swift
@@ -11,7 +11,7 @@ class FormListViewController: UITableViewController {
         super.viewDidLoad()
         
         spinner = UIActivityIndicatorView.init(activityIndicatorStyle: .Gray)
-        spinner.center = CGPointMake(160, 240);
+        spinner.center = CGPointMake(self.view.frame.size.width/2.0, 22);
         spinner.hidesWhenStopped = true;
         self.view.addSubview(spinner)
         spinner.startAnimating()

--- a/AppConnectSwift/LoginViewController.swift
+++ b/AppConnectSwift/LoginViewController.swift
@@ -12,10 +12,6 @@ class LoginViewController: UIViewController {
         super.viewDidLoad()
         
         loginButton.setTitle("Logging In", forState: UIControlState.Disabled)
-        
-        MDClient.setEnvironment(.Validation);
-        usernameField.text = "sdk@101.com" //"sub02@sqa.com"
-        passwordField.text = "Password90" //"Password1"
     }
     
     @IBAction func doLogin(sender: UIButton) {


### PR DESCRIPTION
This PR centers the spinner. I also removed the credentials and environment. I'll look into making these configuration like in the android sample app, but wanted to remove them now so we don't forget before open-sourced. We will still have to retire these specific credentials as they'll exist in the git history.

![screen shot 2016-01-20 at 11 32 31 am](https://cloud.githubusercontent.com/assets/5994947/12455486/e4f75f18-bf69-11e5-869d-1d39318ef62e.png)
