### PR TITLE
MCC-207941 - bump babbage pod version

### DIFF
--- a/AppConnectSwift/Babbage.podspec
+++ b/AppConnectSwift/Babbage.podspec
@@ -3,13 +3,13 @@ password = ENV['ARTIFACTORY_PASSWORD'] || raise("You must set an artifactory pas
 
 Pod::Spec.new do |s|
     s.name               = "Babbage"
-    s.version            = "1.1-pre.141"
+    s.version            = "2016.1.0.18"
     s.summary            = "The Medidata Patient Cloud SDK"
     s.homepage           = "https://github.com/mdsol/babbage"
     s.license            = { type: "Proprietary", text: "TBD" }
     s.author             = "Medidata Solutions, Inc."
 
-    s.source             = { http: "https://#{username}:#{password}@etlhydra-artifactory-sandbox.imedidata.net/artifactory/p-cloud-snapshots/com/mdsol/babbage/ios/1.1-pre.141/babbage-1.1-pre.141.zip" }
+    s.source             = { http: "https://#{username}:#{password}@etlhydra-artifactory-sandbox.imedidata.net/artifactory/p-cloud-release/com/mdsol/babbage/ios/2016.1.0/babbage-2016.1.0.18.zip" }
     s.source_files       = "artifacts/include/babbage/*.h"
     s.vendored_libraries = "artifacts/libBabbage.a"
 

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -20,7 +20,7 @@ PODS:
   - AFNetworking/UIKit (2.5.3):
     - AFNetworking/NSURLConnection
     - AFNetworking/NSURLSession
-  - Babbage (1.1-pre.141):
+  - Babbage (2016.1.0.18):
     - AFNetworking (= 2.5.3)
     - HTMLReader (~> 0.7.1)
     - OpenSSL-Universal (~> 1.0.1j)
@@ -40,7 +40,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AFNetworking: e1d86c2a96bb5d2e7408da36149806706ee122fe
-  Babbage: 90311d1e037999c425b90218b4d4bde00d32491e
+  Babbage: 4c14a3d9dad2b330083ba65adfbb0c68beed5d8f
   HTMLReader: e6ba09514d125f45e810b6c6c1cebf3542f04d89
   IQKeyboardManagerSwift: 111f01f029d9cda0647a2156d3b6efc24ad1e7f1
   OpenSSL-Universal: 85ef63bf81d0741b03c8719cd29685c37c59518d


### PR DESCRIPTION
This uses the release version of AppConnect/Babbage in the Sample App. Please give this branch a sanity check (pull and build with pod install) thanks!
