### PR TITLE
Adding Babbage pods as a dependency independent of target also to make it run on physical device

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -6,5 +6,5 @@ pod 'IQKeyboardManagerSwift'
 pod 'Babbage', podspec: 'AppConnectSwift/Babbage.podspec'
 
 target 'AppConnectSwift' do
-  pod 'Babbage', podspec: 'AppConnectSwift/Babbage.podspec'
+  # Inherits global pods
 end

--- a/Podfile
+++ b/Podfile
@@ -1,7 +1,9 @@
 source 'https://github.com/CocoaPods/Specs.git'
 
-pod 'IQKeyboardManagerSwift'
 use_frameworks!
+
+pod 'IQKeyboardManagerSwift'
+pod 'Babbage', podspec: 'AppConnectSwift/Babbage.podspec'
 
 target 'AppConnectSwift' do
   pod 'Babbage', podspec: 'AppConnectSwift/Babbage.podspec'


### PR DESCRIPTION
This PR contains:
- Fixes for App-connect-swift sample to run on physical device.

It makes "babbage pods dependency" to be target independent.
