### PR TITLE
MCC-227851: Updating babbage version, adding alerts for account creation and image saving

### DIFF
--- a/AppConnectSwift/Babbage.podspec
+++ b/AppConnectSwift/Babbage.podspec
@@ -11,13 +11,13 @@ end
 
 Pod::Spec.new do |s|
     s.name               = "Babbage"
-    s.version            = "2016.2.0.81"
+    s.version            = "2016.2.0.82"
     s.summary            = "The Medidata Patient Cloud SDK"
     s.homepage           = "https://github.com/mdsol/babbage"
     s.license            = { type: "Proprietary", text: "TBD" }
     s.author             = "Medidata Solutions, Inc."
 
-    s.source             = { http: "https://#{username}:#{password}@etlhydra-artifactory-sandbox.imedidata.net/artifactory/p-cloud-release/com/mdsol/babbage/ios/2016.2.0/babbage-2016.2.0.81.zip" }
+    s.source             = { http: "https://#{username}:#{password}@etlhydra-artifactory-sandbox.imedidata.net/artifactory/p-cloud-release/com/mdsol/babbage/ios/2016.2.0/babbage-2016.2.0.82.zip" }
     s.source_files       = "artifacts/include/babbage/*.h"
     s.vendored_libraries = "artifacts/libBabbage.a"
 

--- a/AppConnectSwift/CaptureImageViewController.swift
+++ b/AppConnectSwift/CaptureImageViewController.swift
@@ -56,7 +56,7 @@ class CaptureImageViewController: UIViewController, UIImagePickerControllerDeleg
     }
     
     @IBAction func saveTapped(sender: AnyObject) {
-        if image.CGImage != nil {
+        if image.CGImage != nil && self.imageView.image != nil {
           var bgQueue : NSOperationQueue! = NSOperationQueue()
             bgQueue.addOperationWithBlock() {
                 let clientFactory = MDClientFactory.sharedInstance()
@@ -78,6 +78,13 @@ class CaptureImageViewController: UIViewController, UIImagePickerControllerDeleg
                             else if err.description.containsString("The Internet connection appears to be offline"){
                                 NSOperationQueue.mainQueue().addOperationWithBlock {
                                     self.showAlert("Not connected to the Internet", message: "Please restore Internet connection and try again")
+                                    bgQueue = nil
+                                    datastore = nil
+                                }
+                            }
+                            else {
+                                NSOperationQueue.mainQueue().addOperationWithBlock {
+                                    self.showAlert("Unable to save data", message: "Unable to save data as \(err)")
                                     bgQueue = nil
                                     datastore = nil
                                 }

--- a/AppConnectSwift/CaptureImageViewController.swift
+++ b/AppConnectSwift/CaptureImageViewController.swift
@@ -68,7 +68,7 @@ class CaptureImageViewController: UIViewController, UIImagePickerControllerDeleg
                         client.sendEnvelope(dataEnvelope, completion: { (err) in
                             if err == nil {
                                 NSOperationQueue.mainQueue().addOperationWithBlock {
-                                    self.showAlert("Save Image", message: "Data saved successfully")
+                                    self.showAlert("Data saved successfully", message: "")
                                     self.imageView.image = nil
                                     subject = nil
                                     bgQueue = nil
@@ -101,7 +101,7 @@ class CaptureImageViewController: UIViewController, UIImagePickerControllerDeleg
             }
         }
         else {
-            showAlert("No image", message: "Image selected has no path")
+            showAlert("No image selected", message: "")
         }
     }
     
@@ -113,7 +113,7 @@ class CaptureImageViewController: UIViewController, UIImagePickerControllerDeleg
                 presentViewController(imagePicker, animated: true, completion: {})
             }
             else {
-                showAlert("Camera not accessible", message: "AppConnect cannot access the camera.")
+                showAlert("Camera not accessible", message: "")
             }
         }
         else {

--- a/AppConnectSwift/CaptureImageViewController.swift
+++ b/AppConnectSwift/CaptureImageViewController.swift
@@ -84,7 +84,7 @@ class CaptureImageViewController: UIViewController, UIImagePickerControllerDeleg
                             }
                             else {
                                 NSOperationQueue.mainQueue().addOperationWithBlock {
-                                    self.showAlert("Unable to save data", message: "Unable to save data as \(err)")
+                                    self.showAlert("Unable to save data", message: "\(err)")
                                     bgQueue = nil
                                     datastore = nil
                                 }

--- a/AppConnectSwift/CaptureImageViewController.swift
+++ b/AppConnectSwift/CaptureImageViewController.swift
@@ -84,7 +84,7 @@ class CaptureImageViewController: UIViewController, UIImagePickerControllerDeleg
                             }
                             else {
                                 NSOperationQueue.mainQueue().addOperationWithBlock {
-                                    self.showAlert("Unable to save data", message: "\(err)")
+                                    self.showAlert("Unable to save data", message: err.description)
                                     bgQueue = nil
                                     datastore = nil
                                 }
@@ -92,7 +92,7 @@ class CaptureImageViewController: UIViewController, UIImagePickerControllerDeleg
                         })
                     }
                     else{
-                        print(err?.description)
+                        self.showAlert("", message: err.description)
                         bgQueue = nil
                         datastore = nil
                         subject = nil

--- a/AppConnectSwift/CreateAccountViewController.swift
+++ b/AppConnectSwift/CreateAccountViewController.swift
@@ -27,7 +27,7 @@ class CreateAccountViewController: UIViewController {
                     })
                 }
                 else {
-                    self.showAlert("Account Creation Failure", message: "\(err!)" )
+                    self.showAlert("Account Creation Failure", message: err.description)
                 }
             }
         }

--- a/AppConnectSwift/CreateAccountViewController.swift
+++ b/AppConnectSwift/CreateAccountViewController.swift
@@ -18,16 +18,24 @@ class CreateAccountViewController: UIViewController {
     @IBAction func createAccount(sender: AnyObject) {
         let clientFactory = MDClientFactory.sharedInstance()
         let client = clientFactory.clientOfType(MDClientType.Network);
-        client.registerSubjectWithEmail(userEmail, password: userPassword, securityQuestionID: userSecurityQuestionID, securityQuestionAnswer: securityQuestionLabel.text) { (err) in
-            if err == nil {
-                NSOperationQueue.mainQueue().addOperationWithBlock({ 
-                    self.performSegueWithIdentifier("CreateAccountSuccess", sender: nil)
-                })
-            }
-            else {
-                print(err?.description)
+        if userSecurityQuestionAnswer.text?.characters.count >= 2 {
+            client.registerSubjectWithEmail(userEmail, password: userPassword, securityQuestionID: userSecurityQuestionID, securityQuestionAnswer: userSecurityQuestionAnswer.text) { (err) in
+                if err == nil {
+                    NSOperationQueue.mainQueue().addOperationWithBlock({
+                        self.showAlert("Account Creation Success", message: "Created account successfully" )
+                        self.performSegueWithIdentifier("CreateAccountSuccess", sender: nil)
+                    })
+                }
+                else {
+                    print(err?.description)
+                    self.showAlert("Account Creation Failure", message: "Unable to create account as \(err!)" )
+                }
             }
         }
+        else {
+            
+        }
+        
     }
     
     override func prepareForSegue(segue: UIStoryboardSegue, sender: AnyObject?) {
@@ -35,5 +43,11 @@ class CreateAccountViewController: UIViewController {
         if segue.identifier == "CreateAccountSuccess" {
             let loginViewController = segue.destinationViewController as! LoginViewController
         }
+    }
+    
+    func showAlert(title: String, message: String) {
+        let alert = UIAlertController(title: title, message: message, preferredStyle: UIAlertControllerStyle.Alert)
+        alert.addAction(UIAlertAction(title: "OK", style: UIAlertActionStyle.Default, handler: nil))
+        self.presentViewController(alert, animated: true, completion: nil)
     }
 }

--- a/AppConnectSwift/CreateAccountViewController.swift
+++ b/AppConnectSwift/CreateAccountViewController.swift
@@ -22,18 +22,18 @@ class CreateAccountViewController: UIViewController {
             client.registerSubjectWithEmail(userEmail, password: userPassword, securityQuestionID: userSecurityQuestionID, securityQuestionAnswer: userSecurityQuestionAnswer.text) { (err) in
                 if err == nil {
                     NSOperationQueue.mainQueue().addOperationWithBlock({
-                        self.showAlert("Account Creation Success", message: "Created account successfully" )
+                        self.showAlert("Account Creation Success", message: "Created account successfully")
                         self.performSegueWithIdentifier("CreateAccountSuccess", sender: nil)
                     })
                 }
                 else {
                     print(err?.description)
-                    self.showAlert("Account Creation Failure", message: "Unable to create account as \(err!)" )
+                    self.showAlert("Account Creation Failure", message: "\(err!)" )
                 }
             }
         }
         else {
-           self.showAlert("Account Creation Failure", message: "Security answer to be at least 2 characters long." ) 
+           self.showAlert("Account Creation Failure", message: "Security answer must be at least 2 characters long.")
         }
         
     }

--- a/AppConnectSwift/CreateAccountViewController.swift
+++ b/AppConnectSwift/CreateAccountViewController.swift
@@ -33,7 +33,7 @@ class CreateAccountViewController: UIViewController {
             }
         }
         else {
-            
+           self.showAlert("Account Creation Failure", message: "Security answer to be at least 2 characters long." ) 
         }
         
     }

--- a/AppConnectSwift/CreateAccountViewController.swift
+++ b/AppConnectSwift/CreateAccountViewController.swift
@@ -22,12 +22,11 @@ class CreateAccountViewController: UIViewController {
             client.registerSubjectWithEmail(userEmail, password: userPassword, securityQuestionID: userSecurityQuestionID, securityQuestionAnswer: userSecurityQuestionAnswer.text) { (err) in
                 if err == nil {
                     NSOperationQueue.mainQueue().addOperationWithBlock({
-                        self.showAlert("Account Creation Success", message: "Created account successfully")
+                        self.showAlert("Account Creation Success", message: "")
                         self.performSegueWithIdentifier("CreateAccountSuccess", sender: nil)
                     })
                 }
                 else {
-                    print(err?.description)
                     self.showAlert("Account Creation Failure", message: "\(err!)" )
                 }
             }

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,7 +23,7 @@ PODS:
   - AWSCore (2.3.6)
   - AWSS3 (2.3.6):
     - AWSCore (= 2.3.6)
-  - Babbage (2016.2.0.81):
+  - Babbage (2016.2.0.82):
     - AFNetworking (= 2.5.3)
     - AWSS3 (~> 2.3.5)
     - HTMLReader (~> 0.7.1)
@@ -46,7 +46,7 @@ SPEC CHECKSUMS:
   AFNetworking: e1d86c2a96bb5d2e7408da36149806706ee122fe
   AWSCore: 917d84b32974136194a905b98c0ae25c9f3350b8
   AWSS3: 1caaf6b45100503fecf3d418c394519a89409a74
-  Babbage: d2e4a3874e3143411315d007d034cfedbc8b4614
+  Babbage: bfd23e9ef30227337bcba861e8d0a484d346d274
   HTMLReader: e6ba09514d125f45e810b6c6c1cebf3542f04d89
   IQKeyboardManagerSwift: 7d06186460470f3f7e767630861a1303980ee5cf
   OpenSSL-Universal: 79fd751a7b4db41f5b430e767c9bbf681b5c8330


### PR DESCRIPTION
PR includes:
1) Versioning up babbage to .82
2) Image view empty or not checked to show alerts if image already saved and user needs to add new image
3) Security answers to be saved accurately
4) Security answers to be at least 2 characters long.
5) Alert with error in case of image save failure
## Screenshot for issue-2 ##

<img width="423" alt="screen shot 2016-05-06 at 1 40 44 pm" src="https://cloud.githubusercontent.com/assets/7715859/15082766/8950b7fe-1397-11e6-84a7-269659b477ae.png">
## Screenshot for issue-4

![screen shot 2016-05-06 at 2 38 16 pm](https://cloud.githubusercontent.com/assets/7715859/15082881/394ea95e-1398-11e6-8501-d19d9c9f1912.png)
## Screenshot for issue-5

<img width="313" alt="screen shot 2016-05-06 at 11 30 59 am" src="https://cloud.githubusercontent.com/assets/7715859/15082765/894ad1d6-1397-11e6-97ac-59168e9fbf1e.png">
