### PR TITLE
MCC-232377 - update sample to use hybrid client

### DIFF
--- a/AppConnectSwift/AppDelegate.swift
+++ b/AppConnectSwift/AppDelegate.swift
@@ -5,7 +5,6 @@ import IQKeyboardManagerSwift
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
-    var client: MDClient?
     var UIDatastore: MDDatastore?
 
     func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
@@ -18,11 +17,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let key = "12345678901234567890123456789012".dataUsingEncoding(NSUTF8StringEncoding)
         // TODO: Substitute the apiToken value with proper token
         MDBabbage.startWithEnvironment(MDClientEnvironment.Production, apiToken: "Your API token", publicDirectory: dir, privateDirectory: dir, encryptionKey: key)
-        
-        // The client that will be used to make requests to the backend can be
-        // created once and reused as needed throughout the app
-        client = MDClientFactory.sharedInstance().clientOfType(MDClientType.Network)
-        
+
         // All UI code must get objects from the same datastore, so it's a good
         // idea to create it once and make it available to the rest of the app
         UIDatastore = MDDatastoreFactory.create()

--- a/AppConnectSwift/Babbage.podspec
+++ b/AppConnectSwift/Babbage.podspec
@@ -11,13 +11,13 @@ end
 
 Pod::Spec.new do |s|
     s.name               = "Babbage"
-    s.version            = "2016.2.0.84"
+    s.version            = "2016.2.0.115"
     s.summary            = "The Medidata Patient Cloud SDK"
     s.homepage           = "https://github.com/mdsol/babbage"
     s.license            = { type: "Proprietary", text: "TBD" }
     s.author             = "Medidata Solutions, Inc."
 
-    s.source             = { http: "https://#{username}:#{password}@etlhydra-artifactory-sandbox.imedidata.net/artifactory/p-cloud-release/com/mdsol/babbage/ios/2016.2.0/babbage-2016.2.0.84.zip" }
+    s.source             = { http: "https://#{username}:#{password}@etlhydra-artifactory-sandbox.imedidata.net/artifactory/p-cloud-release/com/mdsol/babbage/ios/2016.3.0/babbage-2016.3.0.115.zip" }
     s.source_files       = "artifacts/include/babbage/*.h"
     s.vendored_libraries = "artifacts/libBabbage.a"
 

--- a/AppConnectSwift/CaptureImageViewController.swift
+++ b/AppConnectSwift/CaptureImageViewController.swift
@@ -59,45 +59,23 @@ class CaptureImageViewController: UIViewController, UIImagePickerControllerDeleg
         if image.CGImage != nil && self.imageView.image != nil {
           var bgQueue : NSOperationQueue! = NSOperationQueue()
             bgQueue.addOperationWithBlock() {
-                let clientFactory = MDClientFactory.sharedInstance()
-                let client = clientFactory.clientOfType(MDClientType.Network);
                 var datastore = MDDatastoreFactory.create()
                 var subject = datastore.subjectWithID(self.subjectID)
                 
-                subject.collectData(self.data, withMetadata: "Random String", contentType: "image/jpeg", completion: { (dataEnvelope:  MDSubjectDataEnvelope!, err: NSError!) -> Void in
+                subject.collectData(self.data, withMetadata: "Random String", contentType: "image/jpeg", completion: { (err: NSError!) -> Void in
                     if err == nil {
-                        client.sendEnvelope(dataEnvelope, completion: { (err) in
-                            if err == nil {
-                                NSOperationQueue.mainQueue().addOperationWithBlock {
-                                    self.showAlert("Data saved successfully", message: "")
-                                    self.imageView.image = nil
-                                    subject = nil
-                                    bgQueue = nil
-                                    datastore = nil
-                                }
-                            }
-                            else if err.description.containsString("The Internet connection appears to be offline"){
-                                NSOperationQueue.mainQueue().addOperationWithBlock {
-                                    self.showAlert("Not connected to the Internet", message: "Please restore Internet connection and try again")
-                                    bgQueue = nil
-                                    datastore = nil
-                                }
-                            }
-                            else {
-                                NSOperationQueue.mainQueue().addOperationWithBlock {
-                                    self.showAlert("Unable to save data", message: err.description)
-                                    bgQueue = nil
-                                    datastore = nil
-                                }
-                            }
+                        NSOperationQueue.mainQueue().addOperationWithBlock({
+                            self.imageView.image = nil
+                            self.showAlert("Data Saved", message: "Upload will happen automatically.")
+                        });
+                    } else {
+                        NSOperationQueue.mainQueue().addOperationWithBlock({
+                            self.showAlert("", message: err.description)
                         })
                     }
-                    else{
-                        self.showAlert("", message: err.description)
-                        bgQueue = nil
-                        datastore = nil
-                        subject = nil
-                    }
+                    bgQueue = nil
+                    datastore = nil
+                    subject = nil
                 })
             }
         }
@@ -112,12 +90,10 @@ class CaptureImageViewController: UIViewController, UIImagePickerControllerDeleg
             if UIImagePickerController.isSourceTypeAvailable(.Camera) {
                 imagePicker.sourceType = .Camera
                 presentViewController(imagePicker, animated: true, completion: {})
-            }
-            else {
+            } else {
                 showAlert("Camera not accessible", message: "")
             }
-        }
-        else {
+        } else {
             // Looks for images in photo library
             imagePicker.sourceType = .PhotoLibrary
             presentViewController(imagePicker, animated: true, completion: {})
@@ -128,7 +104,7 @@ class CaptureImageViewController: UIViewController, UIImagePickerControllerDeleg
         var bgQueue : NSOperationQueue! = NSOperationQueue()
         bgQueue.addOperationWithBlock() {
             let clientFactory = MDClientFactory.sharedInstance()
-            let client = clientFactory.clientOfType(MDClientType.Network);
+            let client = clientFactory.clientOfType(MDClientType.Hybrid);
             var datastore = MDDatastoreFactory.create()
             let user = datastore.userWithID(self.userID)
             
@@ -170,13 +146,11 @@ class CaptureImageViewController: UIViewController, UIImagePickerControllerDeleg
                 // Adjusting larger width
                 imgWidth = adjustedHeight / imgHeight * imgWidth;
                 imgHeight = adjustedHeight
-            }
-            else if imgAspectRatio > adjustedAspectRatio {
+            } else if imgAspectRatio > adjustedAspectRatio {
                 // Adjusting larger height
                 imgHeight = adjustedWidth / imgWidth * imgHeight
                 imgWidth = adjustedWidth
-            }
-            else {
+            } else {
                 // No compression
                 imgWidth = adjustedWidth;
                 imgHeight = adjustedHeight;

--- a/AppConnectSwift/CreateAccountViewController.swift
+++ b/AppConnectSwift/CreateAccountViewController.swift
@@ -17,7 +17,7 @@ class CreateAccountViewController: UIViewController {
     
     @IBAction func createAccount(sender: AnyObject) {
         let clientFactory = MDClientFactory.sharedInstance()
-        let client = clientFactory.clientOfType(MDClientType.Network);
+        let client = clientFactory.clientOfType(MDClientType.Hybrid);
         if userSecurityQuestionAnswer.text?.characters.count >= 2 {
             client.registerSubjectWithEmail(userEmail, password: userPassword, securityQuestionID: userSecurityQuestionID, securityQuestionAnswer: userSecurityQuestionAnswer.text) { (err) in
                 if err == nil {

--- a/AppConnectSwift/FormListViewController.swift
+++ b/AppConnectSwift/FormListViewController.swift
@@ -37,7 +37,7 @@ class FormListViewController: UITableViewController {
             // Each secondary thread must create its own datastore instance and
             // dispose of it when done
             let clientFactory = MDClientFactory.sharedInstance()
-            let client = clientFactory.clientOfType(MDClientType.Network);
+            let client = clientFactory.clientOfType(MDClientType.Hybrid);
             var datastore = MDDatastoreFactory.create()
             let user = datastore.userWithID(Int64(self.userID))
             

--- a/AppConnectSwift/LoginViewController.swift
+++ b/AppConnectSwift/LoginViewController.swift
@@ -26,7 +26,7 @@ class LoginViewController: UIViewController {
         let password = passwordField.text
         
         let clientFactory = MDClientFactory.sharedInstance()
-        let client = clientFactory.clientOfType(MDClientType.Network);
+        let client = clientFactory.clientOfType(MDClientType.Hybrid);
         
         var bgQueue : NSOperationQueue! = NSOperationQueue()
         bgQueue.addOperationWithBlock {

--- a/AppConnectSwift/MultiPageFormViewController.swift
+++ b/AppConnectSwift/MultiPageFormViewController.swift
@@ -57,8 +57,8 @@ class MultiPageFormViewController: UIViewController, UIPageViewControllerDelegat
         // a signature, form.sign() should also be called before calling finish().
         stepSequencer.finish()
         
-        // Create a network client instance with which to send the responses
-        let client = MDClientFactory.sharedInstance().clientOfType(MDClientType.Network);
+        // Create a hybrid client instance with which to send the responses
+        let client = MDClientFactory.sharedInstance().clientOfType(MDClientType.Hybrid);
         
         // Create a new datastore to use for the request
         var datastore = MDDatastoreFactory.create()

--- a/AppConnectSwift/OnePageFormViewController.swift
+++ b/AppConnectSwift/OnePageFormViewController.swift
@@ -74,7 +74,7 @@ class OnePageFormViewController: UIViewController {
         }
         
         // Create a network client instance with which to send the responses
-        let client = MDClientFactory.sharedInstance().clientOfType(MDClientType.Network);
+        let client = MDClientFactory.sharedInstance().clientOfType(MDClientType.Hybrid);
         
         // Babbage objects can't be shared between threads so you must pass
         // them around by ID instead and the receiving code can get its own

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -23,7 +23,7 @@ PODS:
   - AWSCore (2.3.6)
   - AWSS3 (2.3.6):
     - AWSCore (= 2.3.6)
-  - Babbage (2016.2.0.84):
+  - Babbage (2016.2.0.115):
     - AFNetworking (= 2.5.3)
     - AWSS3 (~> 2.3.5)
     - HTMLReader (~> 0.7.1)
@@ -46,7 +46,7 @@ SPEC CHECKSUMS:
   AFNetworking: e1d86c2a96bb5d2e7408da36149806706ee122fe
   AWSCore: 917d84b32974136194a905b98c0ae25c9f3350b8
   AWSS3: 1caaf6b45100503fecf3d418c394519a89409a74
-  Babbage: 0377440ad0906736d4b22843cc0a1c315a81f9d7
+  Babbage: 8e66b69c8a2f20ba6d487824405f341da444380a
   HTMLReader: e6ba09514d125f45e810b6c6c1cebf3542f04d89
   IQKeyboardManagerSwift: 7d06186460470f3f7e767630861a1303980ee5cf
   OpenSSL-Universal: 07489b0316f0f4f53c928e402e2ecbbedf96d93b


### PR DESCRIPTION
This PR updates the sample app to use the Hybrid Client. I also did some cleanup:
- used `} else {` syntax rather than else on newline (to be consistent with our normal usage)
- removed the `client` from AppDelegate that was never used
- updated the data collection since it is now automatically uploaded
