### PR TITLE
MCC-247837 - add example of api token not associated with user during login

### DIFF
--- a/AppConnectSwift/Babbage.podspec
+++ b/AppConnectSwift/Babbage.podspec
@@ -1,5 +1,5 @@
 RELEASE = "2016.3.0"
-VERSION = "#{RELEASE}.122"
+VERSION = "#{RELEASE}.135"
 
 if File.exist?('local.yaml')
     require 'yaml'

--- a/AppConnectSwift/LoginViewController.swift
+++ b/AppConnectSwift/LoginViewController.swift
@@ -32,8 +32,12 @@ class LoginViewController: UIViewController {
             if(error != nil) {
                 var alertMessage = error.localizedDescription;
                 
-                if(MDClientErrorCause(rawValue: error.code) == MDClientErrorCause.AuthenticationFailure) {
+                let errorCause = MDClientErrorCause(rawValue: error.code)
+                
+                if(errorCause == MDClientErrorCause.AuthenticationFailure) {
                     alertMessage = "The provided credentials are incorrect."
+                } else if (errorCause == MDClientErrorCause.UserNotAssociatedWithToken) {
+                    alertMessage = "User is not associated with provided API token."
                 }
                 
                 NSOperationQueue.mainQueue().addOperationWithBlock({

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -2,7 +2,7 @@ PODS:
   - AWSCore (2.3.6)
   - AWSS3 (2.3.6):
     - AWSCore (= 2.3.6)
-  - Babbage (2016.3.0.122):
+  - Babbage (2016.3.0.135):
     - AWSS3 (~> 2.3.5)
     - HTMLReader (~> 0.7)
     - UICKeyChainStore (~> 2.0)
@@ -21,7 +21,7 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   AWSCore: 917d84b32974136194a905b98c0ae25c9f3350b8
   AWSS3: 1caaf6b45100503fecf3d418c394519a89409a74
-  Babbage: 6f73da258570eb08ca66ca8baa05855db91b1820
+  Babbage: 50e963388317ce3d76249c58e5cd00a0165db6ed
   HTMLReader: 7e21488ee378afc56ccade8af35840c4e03e434c
   IQKeyboardManagerSwift: 7d06186460470f3f7e767630861a1303980ee5cf
   UICKeyChainStore: f1cbd42216a113f0165de1e733e62905b8823432


### PR DESCRIPTION
This PR adds an example of receiving the `UserNotAssociatedWithToken` error when logging in via AppConnect.
